### PR TITLE
Remove the glusterfs_repo attribute form python-gdeploy conf

### DIFF
--- a/etc/python-gdeploy/python-gdeploy.conf.sample
+++ b/etc/python-gdeploy/python-gdeploy.conf.sample
@@ -1,2 +1,0 @@
-[python-gdeploy]
-glusterfs_repo = https://buildlogs.centos.org/centos/7/storage/x86_64/gluster-3.9/

--- a/python-gdeploy.spec
+++ b/python-gdeploy.spec
@@ -27,8 +27,6 @@ rm -rf %{name}.egg-info
 
 %install
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
-install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/python-gdeploy
-install -Dm 0644 etc/python-gdeploy/python-gdeploy.conf.sample  $RPM_BUILD_ROOT%{_sysconfdir}/python-gdeploy/python-gdeploy.conf
 
 %check
 py.test -v python_gdeploy/tests || :

--- a/python_gdeploy/actions/install_gluster.py
+++ b/python_gdeploy/actions/install_gluster.py
@@ -16,12 +16,6 @@ GLUSTERFS_PACKAGES = [
 ]
 
 
-def get_glusterfs_repo():
-    config = ConfigParser.SafeConfigParser()
-    config.read('/etc/python-gdeploy/python-gdeploy.conf')
-    return config.get("python-gdeploy", "glusterfs_repo")
-
-
 def install_gluster_packages(host_list,
                              glusterfs_packages=None,
                              glusterfs_repo=None,
@@ -40,7 +34,7 @@ def install_gluster_packages(host_list,
         gf.get_yum(
             "install",
             glusterfs_packages if glusterfs_packages else GLUSTERFS_PACKAGES,
-            glusterfs_repo if glusterfs_repo else get_glusterfs_repo(),
+            glusterfs_repo,
             gpgcheck if gpgcheck else "no"
         )
     )


### PR DESCRIPTION
The glusterfs repo is maintained in tendrl-node-agent so this
is a redundant information. Hence removing this from python-
gdeploy

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>